### PR TITLE
Show stream items on homepage

### DIFF
--- a/assets/css/layout/page.scss
+++ b/assets/css/layout/page.scss
@@ -7,6 +7,10 @@ html {
   text-rendering: optimizeLegibility;
 }
 
+[id] {
+  scroll-margin-top: 2rem;
+}
+
 body {
   font-family: $font;
   font-size: 1.6rem;

--- a/components/StreamItem/index.tsx
+++ b/components/StreamItem/index.tsx
@@ -27,7 +27,7 @@ export default function StreamItem({ post }: { post: Post }): JSX.Element {
   return (
     <article>
       <div className="StreamItem__heading desktop:d-flex align-bottom">
-        <h2>{post.title}</h2>
+        <h2 id={post.slug}>{post.title}</h2>
 
         <div className="text-accent">
           <FullDate datetime={post.created_at} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,14 @@ import { getAllPosts } from '../lib/api.ts';
 import { byDate } from '../util/sort.js';
 import { longDate } from '../util/date';
 
+function getLink(post) {
+  if (post.type === 'stream') {
+    return `/stream#${post.slug}`;
+  }
+
+  return `/blog/${post.slug}`;
+}
+
 function Home({ latest }) {
   return (
     <div className="Home">
@@ -22,7 +30,7 @@ function Home({ latest }) {
             <li className="BlogPost" key={post.title}>
               <article className="BlogPost">
                 <h3 className="t-large mb-0 font-regular">
-                  <Link href={`/blog/${post.slug}`} prefetch={false}>
+                  <Link href={getLink(post)} prefetch={false}>
                     <a className="link">{post.title}</a>
                   </Link>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -41,9 +41,15 @@ function Home({ latest }) {
 }
 
 export async function getStaticProps() {
-  const posts = await getAllPosts('posts');
+  const [posts, stream] = await Promise.all([
+    getAllPosts('posts'),
+    getAllPosts('stream'),
+  ]);
 
-  return { props: { latest: posts.slice(0, 3) } };
+  const all = [...posts, ...stream]
+    .sort((p1, p2) => (new Date(p1.created_at)) < (new Date(p2.created_at)) ? 1 : -1);
+
+  return { props: { latest: all.slice(0, 3) } };
 }
 
 export default Home;


### PR DESCRIPTION
Closes #29.

Adds stream items to the 3 latest posts on the homepage. For stream items, links directly to the stream with hash navigation to the correct stream item.