### PR TITLE
Save active tags to query params

### DIFF
--- a/lib/useTags.ts
+++ b/lib/useTags.ts
@@ -1,10 +1,23 @@
+import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { Post, PostFrontMatter, Tag } from "./types";
 
 
 export default function useTags(posts: Post[]) {
-  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const router = useRouter()
+  const [activeTags, setActiveTags] = useState<string[]>(getTagsFromQuery());
   const [filtered, setFiltered] = useState(posts);
+
+  function getTagsFromQuery() {
+    if (typeof window === 'undefined') return [];
+
+    const query = (new URL(window.location.href)).searchParams.get('tags');
+    if (query) {
+      return query.split(',');
+    }
+
+    return []
+  }
 
   const allTags = posts.reduce((tags, post) => {
     if (!post.tags) return tags;
@@ -64,6 +77,15 @@ export default function useTags(posts: Post[]) {
     const newPosts = posts.filter(isPostActive);
     setFiltered(newPosts)
   }, [posts, activeTags, isPostActive])
+
+  useEffect(() => {
+    let query = '';
+    if (activeTags.length) {
+      query = `?tags=${activeTags.join(',')}`;
+    };
+
+    router.replace(window.location.pathname + query);
+  }, [router, activeTags])
 
   return {
     tags: allTags,

--- a/lib/useTags.ts
+++ b/lib/useTags.ts
@@ -17,7 +17,7 @@ export default function useTags(posts: Post[]) {
     }
 
     return []
-  }
+  };
 
   const allTags = posts.reduce((tags, post) => {
     if (!post.tags) return tags;
@@ -85,7 +85,7 @@ export default function useTags(posts: Post[]) {
     };
 
     router.replace(window.location.pathname + query);
-  }, [router, activeTags])
+  }, [activeTags])
 
   return {
     tags: allTags,


### PR DESCRIPTION
Closes #37.

The idea here is that users should be able to share links to the blog page with active tags pre-enabled—mostly so that I can link people to e.g. my reading just by sending the user to `/blog?tags=books`.