### PR TITLE
Make RSS feed auto-discoverable on homepage

### DIFF
--- a/components/Head/index.js
+++ b/components/Head/index.js
@@ -84,6 +84,7 @@ function Meta() {
       <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png" />
       <link rel="mask-icon" href="/images/safari-pinned-tab.svg" color="#000000" />
       <link rel="shortcut icon" href="/images/favicon.ico" />
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml" title="RSS Feed" />
 
       {!isDev && isBrowser && (
         <script


### PR DESCRIPTION
Closes #22.

I'd already added this for individual blog posts, but for some reason, left it off the homepage. Don't know why I did that.