### PR TITLE
Fix selection text/background colour

### DIFF
--- a/assets/css/settings/type.scss
+++ b/assets/css/settings/type.scss
@@ -114,8 +114,8 @@ strong,
 }
 
 ::selection {
-  background: rgba(var(--text), 0.05);
-  color: var(--primary);
+  background: var(--primary);
+  color: var(--background);
 }
 
 .Post {


### PR DESCRIPTION
Closes #43 

For the longest time, when a user would select text, it would just change the colour of the text, which was awful for accessibility and not very nice to look at either.

This makes the selection have a `--primary` background colour and a `--background` text.