### PR TITLE
Add syntax highlighting back

### DIFF
--- a/assets/css/settings/code.scss
+++ b/assets/css/settings/code.scss
@@ -56,12 +56,16 @@
 /* Atelier-Cave Orange */
 .hljs-number,
 .hljs-meta,
-.hljs-built_in,
 .hljs-builtin-name,
 .hljs-literal,
 .hljs-type,
 .hljs-params {
   color: $properties;
+}
+
+
+.hljs-built_in {
+  color: $classes;
 }
 
 /* Atelier-Cave Green */
@@ -80,7 +84,7 @@
 /* Atelier-Cave Purple */
 .hljs-keyword,
 .hljs-selector-tag {
-  color: #955ae7;
+  color: $types;
 }
 
 .hljs-deletion,

--- a/assets/css/settings/code.scss
+++ b/assets/css/settings/code.scss
@@ -28,6 +28,85 @@
   color: $strings;
 }
 
+.hljs-comment,
+.hljs-quote {
+  color: #7e7887;
+}
+
+/* Atelier-Cave Red */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-regexp,
+.hljs-link,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #be4678;
+}
+
+/* Atelier-Cave Orange */
+.hljs-number,
+.hljs-meta,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params {
+  color: #aa573c;
+}
+
+/* Atelier-Cave Green */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet {
+  color: #2a9292;
+}
+
+/* Atelier-Cave Blue */
+.hljs-title,
+.hljs-section {
+  color: #576ddb;
+}
+
+/* Atelier-Cave Purple */
+.hljs-keyword,
+.hljs-selector-tag {
+  color: #955ae7;
+}
+
+.hljs-deletion,
+.hljs-addition {
+  color: #19171c;
+  display: inline-block;
+  width: 100%;
+}
+
+.hljs-deletion {
+  background-color: #be4678;
+}
+
+.hljs-addition {
+  background-color: #2a9292;
+}
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  background: #19171c;
+  color: #8b8792;
+  padding: 0.5em;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
 .token.selector,
 .token.operator,
 .token.entity,

--- a/assets/css/settings/type.scss
+++ b/assets/css/settings/type.scss
@@ -199,6 +199,10 @@ figure {
   img {
     box-shadow: 0 1px 1px var(--shadow);
   }
+
+  @include widescreen {
+    margin-right: calc(-277px);
+  }
 }
 
 ol {

--- a/assets/css/settings/type.scss
+++ b/assets/css/settings/type.scss
@@ -198,6 +198,7 @@ figure {
 
   img {
     box-shadow: 0 1px 1px var(--shadow);
+    width: 100%;
   }
 
   @include widescreen {

--- a/assets/css/settings/type.scss
+++ b/assets/css/settings/type.scss
@@ -188,6 +188,7 @@ pre {
   background: darken($darkgrey, 2%);
   box-shadow: 0 1px 1px var(--shadow);
   color: $white;
+  tab-size: 4;
 
   @include desktop {
     margin-right: calc(9 * -#{$spacing});

--- a/assets/css/settings/vars.scss
+++ b/assets/css/settings/vars.scss
@@ -3,7 +3,7 @@
 :root {
   /* Default/dark styles */
   --color-mode: 'dark';
-  --shadow: #{darken($darkgrey, 10%)};
+  --shadow: #{darken($darkgrey, 5%)};
   --background: #{$darkgrey};
   --accent: #{$grey};
   --faded: #{$dimwhite};
@@ -57,6 +57,12 @@
 
 @mixin desktop {
   @media (min-width: 769px) {
+    @content;
+  }
+}
+
+@mixin widescreen {
+  @media (min-width: 992px) {
     @content;
   }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,7 @@
 import { Book, BookFrontMatter, PostFrontMatterResponse, PostResponse, Project, Walk } from "./types";
 
+const apiURL = process.env.API_URL;
+
 async function fetchJson(url) {
   return fetch(url).then(r => r.json())
 }
@@ -13,7 +15,7 @@ interface PageResponse {
 }
 
 export async function getPostBySlug<K extends keyof PageResponse>(type: K, slug: string): Promise<PageResponse[K]> {
-  const post = await fetchJson(`https://api.charlesharri.es/${type}/${slug}.json`);
+  const post = await fetchJson(`${apiURL}/${type}/${slug}.json`);
 
   return post
 }
@@ -27,7 +29,7 @@ interface IndexResponse {
 }
 
 export async function getAllPosts<K extends keyof IndexResponse>(type: K): Promise<IndexResponse[K]> {
-  const response = await fetchJson(`https://api.charlesharri.es/${type}.json`);
+  const response = await fetchJson(`${apiURL}/${type}.json`);
 
   return response.data;
 }

--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,7 @@ module.exports = {
   images: { domains: [
     'lastfm.freetls.fastly.net',
     'api.charlesharri.es',
+    'charles-craft.test',
   ]},
   webpack(config, { dev, isServer }) {
     if (!isServer) {


### PR DESCRIPTION
Used to have syntax highlighting with Prism.js, but ever since switching to Craft I haven't had it. I've got Craft to play nice with Highlight.js, though, so while the colours might be a little bit off, at least I've got syntax highlighting again.